### PR TITLE
Increase performance & make it compatible with more browsers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 # Created by .ignore support plugin (hsz.mobi)
 .idea
+.DS_Store

--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@
 
 </head>
 <body>
+<canvas id="fractal"></canvas>
 <script src="js/compy-stuff.js"></script>
 <script src="js/util.js"></script>
 <script src="js/painter.js"></script>

--- a/index.html
+++ b/index.html
@@ -1,20 +1,19 @@
 <!DOCTYPE html>
 <html>
+
 <head>
-  <script
-          src="https://code.jquery.com/jquery-3.4.1.slim.min.js"
-          integrity="sha256-pasqAKBDmFT4eHoN2ndd6lN370kFiGUFyTiUHWhU7k8="
-          crossorigin="anonymous"></script>
   <script src="https://cdn.jsdelivr.net/npm/lodash@4.17.11/lodash.min.js"></script>
   <link rel="stylesheet" type="text/css" href="style.css">
-  <meta charset="utf-8"/>
+  <meta charset="utf-8" />
 
 </head>
+
 <body>
-<canvas id="fractal"></canvas>
-<script src="js/compy-stuff.js"></script>
-<script src="js/util.js"></script>
-<script src="js/painter.js"></script>
-<script src="js/sketch.js"></script>
+  <canvas id="fractal"></canvas>
+  <script src="js/compy-stuff.js"></script>
+  <script src="js/util.js"></script>
+  <script src="js/painter.js"></script>
+  <script src="js/sketch.js"></script>
 </body>
+
 </html>

--- a/index.html
+++ b/index.html
@@ -2,7 +2,6 @@
 <html>
 
 <head>
-  <script src="https://cdn.jsdelivr.net/npm/lodash@4.17.11/lodash.min.js"></script>
   <link rel="stylesheet" type="text/css" href="style.css">
   <meta charset="utf-8" />
 

--- a/index.html
+++ b/index.html
@@ -5,7 +5,6 @@
           src="https://code.jquery.com/jquery-3.4.1.slim.min.js"
           integrity="sha256-pasqAKBDmFT4eHoN2ndd6lN370kFiGUFyTiUHWhU7k8="
           crossorigin="anonymous"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/randomcolor/0.5.4/randomColor.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/lodash@4.17.11/lodash.min.js"></script>
   <link rel="stylesheet" type="text/css" href="style.css">
   <meta charset="utf-8"/>

--- a/index.html
+++ b/index.html
@@ -12,7 +12,9 @@
 
 </head>
 <body>
+<script src="js/compy-stuff.js"></script>
 <script src="js/util.js"></script>
+<script src="js/painter.js"></script>
 <script src="js/sketch.js"></script>
 </body>
 </html>

--- a/js/acolyte.js
+++ b/js/acolyte.js
@@ -27,17 +27,18 @@ self.onmessage = function onmessage(event) {
 }
 
 function draw() {
+    const start = performance.now();
     const data = new Uint8ClampedArray(dimensions.width * dimensions.height * 4);
+
+    const c = { re: 0, im: 0 };
 
     for (let i = 0; i < data.length; i += 4) {
         let x = (i / 4) % dimensions.width;
         let y = (i / 4) / dimensions.width | 0;
         const ax = x + xOffset
 
-        const c = {
-            re: map(ax, 0, maxDimensions.width, xBounds.min, xBounds.max),
-            im: map(y, 0, maxDimensions.height, yBounds.min, yBounds.max)
-        }
+        c.re = map(ax, 0, maxDimensions.width, xBounds.min, xBounds.max);
+        c.im = map(y, 0, maxDimensions.height, yBounds.min, yBounds.max);
 
         const result = testMandelbrot(c, maxIters)
 
@@ -50,7 +51,8 @@ function draw() {
     }
 
     const buffer = data.buffer;
-    self.postMessage({ message: 'draw', buffer }, [buffer]);
+    const time = performance.now() - start;
+    self.postMessage({ message: 'draw', buffer, time }, [buffer]);
 }
 
 

--- a/js/acolyte.js
+++ b/js/acolyte.js
@@ -4,7 +4,7 @@ importScripts('/js/compy-stuff.js')
 let id
 let xBounds
 let yBounds
-let xOffset
+let offset
 let maxDimensions
 let dimensions
 let maxIters
@@ -16,7 +16,7 @@ self.onmessage = function onmessage(event) {
     switch (event.data.message) {
 
         case 'setup':
-            ({ id, xOffset, xBounds, yBounds, dimensions, maxDimensions, maxIters } = event.data)
+            ({ id, offset, xBounds, yBounds, dimensions, maxDimensions, maxIters } = event.data)
             draw()
             break
 
@@ -33,11 +33,10 @@ function draw() {
     const c = { re: 0, im: 0 };
 
     for (let i = 0; i < data.length; i += 4) {
-        let x = (i / 4) % dimensions.width;
-        let y = (i / 4) / dimensions.width | 0;
-        const ax = x + xOffset
+        let x = offset.x + (i / 4) % dimensions.width;
+        let y = offset.y + (i / 4) / dimensions.width | 0;
 
-        c.re = map(ax, 0, maxDimensions.width, xBounds.min, xBounds.max);
+        c.re = map(x, 0, maxDimensions.width, xBounds.min, xBounds.max);
         c.im = map(y, 0, maxDimensions.height, yBounds.min, yBounds.max);
 
         const result = testMandelbrot(c, maxIters)

--- a/js/acolyte.js
+++ b/js/acolyte.js
@@ -1,5 +1,4 @@
-importScripts('https://cdn.jsdelivr.net/npm/lodash@4.17.11/lodash.min.js')
-importScripts('/js/compy-stuff.js')
+importScripts('compy-stuff.js')
 
 let id
 let bounds

--- a/js/acolyte.js
+++ b/js/acolyte.js
@@ -38,10 +38,10 @@ function draw() {
         c.re = map(x, 0, maxDimensions.width, bounds.x.min, bounds.x.max);
         c.im = map(y, 0, maxDimensions.height, bounds.y.min, bounds.y.max);
 
-        const result = testMandelbrot(c, maxIters)
+        const iterBeforeCollapse = testMandelbrot(c, maxIters)
 
-        if (!result.collapses) {
-            const hue = map(result.iterBeforeCollapse, 0, maxIters, 0, 1)
+        if (iterBeforeCollapse < maxIters) {
+            const hue = iterBeforeCollapse / maxIters;
             const rgb = hslToRgb(hue, 1, .5);
             data.set(rgb, i);
         }

--- a/js/acolyte.js
+++ b/js/acolyte.js
@@ -30,7 +30,7 @@ function draw() {
     const data = new Uint8ClampedArray(dimensions.width * dimensions.height * 4);
     const colormap = makeColorMap(maxIters);
 
-    const c = { re: 0, im: 0 };
+    const c = new Complex(0, 0);
 
     for (let i = 0; i < data.length; i += 4) {
         let x = offset.x + (i / 4) % dimensions.width;

--- a/js/acolyte.js
+++ b/js/acolyte.js
@@ -2,8 +2,7 @@ importScripts('https://cdn.jsdelivr.net/npm/lodash@4.17.11/lodash.min.js')
 importScripts('/js/compy-stuff.js')
 
 let id
-let xBounds
-let yBounds
+let bounds
 let offset
 let maxDimensions
 let dimensions
@@ -16,12 +15,12 @@ self.onmessage = function onmessage(event) {
     switch (event.data.message) {
 
         case 'setup':
-            ({ id, offset, xBounds, yBounds, dimensions, maxDimensions, maxIters } = event.data)
+            ({ id, offset, bounds, dimensions, maxDimensions, maxIters } = event.data)
             draw()
             break
 
         case 'draw':
-            ({ xBounds, yBounds, maxIters } = event.data)
+            ({ bounds, maxIters } = event.data)
             draw()
     }
 }
@@ -36,8 +35,8 @@ function draw() {
         let x = offset.x + (i / 4) % dimensions.width;
         let y = offset.y + (i / 4) / dimensions.width | 0;
 
-        c.re = map(x, 0, maxDimensions.width, xBounds.min, xBounds.max);
-        c.im = map(y, 0, maxDimensions.height, yBounds.min, yBounds.max);
+        c.re = map(x, 0, maxDimensions.width, bounds.x.min, bounds.x.max);
+        c.im = map(y, 0, maxDimensions.height, bounds.y.min, bounds.y.max);
 
         const result = testMandelbrot(c, maxIters)
 

--- a/js/acolyte.js
+++ b/js/acolyte.js
@@ -26,7 +26,7 @@ self.onmessage = function onmessage(event) {
     }
 }
 
-async function draw() {
+function draw() {
     const data = new Uint8ClampedArray(dimensions.width * dimensions.height * 4);
 
     for (let i = 0; i < data.length; i += 4) {
@@ -41,18 +41,18 @@ async function draw() {
 
         const result = testMandelbrot(c, maxIters)
 
-        let rgb = [0, 0, 0];
         if (!result.collapses) {
             const hue = map(result.iterBeforeCollapse, 0, maxIters, 0, 1)
-            rgb = hslToRgb(hue, 1, .5);
+            const rgb = hslToRgb(hue, 1, .5);
+            data.set(rgb, i);
         }
-        data.set(rgb, i);
-        data[i + 3] = 255;
+        data[i + 3] = 255; // alpha
     }
 
     const buffer = data.buffer;
     self.postMessage({ message: 'draw', buffer }, [buffer]);
 }
+
 
 function hslToRgb(h, s, l) {
     var r, g, b;
@@ -60,15 +60,6 @@ function hslToRgb(h, s, l) {
     if (s == 0) {
         r = g = b = l; // achromatic
     } else {
-        var hue2rgb = function hue2rgb(p, q, t) {
-            if (t < 0) t += 1;
-            if (t > 1) t -= 1;
-            if (t < 1 / 6) return p + (q - p) * 6 * t;
-            if (t < 1 / 2) return q;
-            if (t < 2 / 3) return p + (q - p) * (2 / 3 - t) * 6;
-            return p;
-        }
-
         var q = l < 0.5 ? l * (1 + s) : l + s - l * s;
         var p = 2 * l - q;
         r = hue2rgb(p, q, h + 1 / 3);
@@ -76,5 +67,14 @@ function hslToRgb(h, s, l) {
         b = hue2rgb(p, q, h - 1 / 3);
     }
 
-    return [Math.round(r * 255), Math.round(g * 255), Math.round(b * 255)];
+    return [r * 255, g * 255, b * 255];
+}
+
+function hue2rgb(p, q, t) {
+    if (t < 0) t += 1;
+    if (t > 1) t -= 1;
+    if (t < 1 / 6) return p + (q - p) * 6 * t;
+    if (t < 1 / 2) return q;
+    if (t < 2 / 3) return p + (q - p) * (2 / 3 - t) * 6;
+    return p;
 }

--- a/js/acolyte.js
+++ b/js/acolyte.js
@@ -28,6 +28,7 @@ self.onmessage = function onmessage(event) {
 function draw() {
     const start = performance.now();
     const data = new Uint8ClampedArray(dimensions.width * dimensions.height * 4);
+    const colormap = makeColorMap(maxIters);
 
     const c = { re: 0, im: 0 };
 
@@ -41,9 +42,9 @@ function draw() {
         const iterBeforeCollapse = testMandelbrot(c, maxIters)
 
         if (iterBeforeCollapse < maxIters) {
-            const hue = iterBeforeCollapse / maxIters;
-            const rgb = hslToRgb(hue, 1, .5);
-            data.set(rgb, i);
+            const idx = iterBeforeCollapse * 3;
+            const color = colormap.subarray(idx, idx + 3);
+            data.set(color, i);
         }
         data[i + 3] = 255; // alpha
     }
@@ -53,6 +54,19 @@ function draw() {
     self.postMessage({ message: 'draw', buffer, time }, [buffer]);
 }
 
+
+const colormaps = [];
+function makeColorMap(size) {
+    if (!colormaps[size]) {
+        const colormap = new Uint8ClampedArray(size * 3);
+        for (let i = 0; i < size; i++) {
+            const rgb = hslToRgb(i / size, 1, .5);
+            colormap.set(rgb, i * 3);
+        }
+        colormaps[size] = colormap;
+    }
+    return colormaps[size];
+}
 
 function hslToRgb(h, s, l) {
     var r, g, b;

--- a/js/compy-stuff.js
+++ b/js/compy-stuff.js
@@ -18,32 +18,13 @@
  * @returns {MandeltestResult}
  */
 function testMandelbrot(c, maxIter = 200) {
-
-    let z = {
-        re: 0,
-        im: 0
-    }
-
-    const result = {
-        iterBeforeCollapse: 0,
-        collapses: true
-    }
-
+    let z = { re: 0, im: 0 }
     for (let i = 0; i < maxIter; i++) {
-
-        result.iterBeforeCollapse++
-
         complexSquare(z);
         complexAdd(z, c);
-
-        if (squareComplexAbs(z) > 4) {
-            result.collapses = false
-            break
-        }
-
+        if (squareComplexAbs(z) > 4) return i;
     }
-
-    return result
+    return maxIter;
 }
 
 /**

--- a/js/compy-stuff.js
+++ b/js/compy-stuff.js
@@ -35,7 +35,7 @@ function testMandelbrot(c, maxIter = 200) {
 
         z = complexAdd(complexMult(z, z), c)
 
-        if (complexAbs(z) > 2) {
+        if (squareComplexAbs(z) > 4) {
             result.collapses = false
             break
         }
@@ -72,29 +72,21 @@ function determineHue(c, dimensions, xBounds, yBounds, maxIters = 200) {
 }
 
 function complexAdd(num1, num2) {
-
-    const result = {}
-
-    result.re = num1.re + num2.re
-    result.im = num1.im + num2.im
-
-    return result
+    return {
+        re: num1.re + num2.re,
+        im: num1.im + num2.im
+    }
 }
 
 function complexMult(num1, num2) {
-
-    const result = {}
-
-    result.re = (num1.re * num2.re) - (num1.im * num2.im)
-    result.im = (num1.re * num2.im) + (num1.im * num2.re)
-
-    return result
+    return {
+        re: (num1.re * num2.re) - (num1.im * num2.im),
+        im: (num1.re * num2.im) + (num1.im * num2.re)
+    }
 }
 
-function complexAbs(num) {
-    return Math.sqrt(
-        Math.pow(num.re, 2) + Math.pow(num.im, 2)
-    )
+function squareComplexAbs(num) {
+    return num.re * num.re + num.im * num.im;
 }
 
 function map(n, start1, stop1, start2, stop2, withinBounds) {

--- a/js/compy-stuff.js
+++ b/js/compy-stuff.js
@@ -6,16 +6,9 @@
  */
 
 /**
- * @typedef {Object} MandeltestResult
- *
- * @property {boolean} collapses
- * @property {number} iterBeforeCollapse
- */
-
-/**
  * @param {Complex} c
  * @param {number} [maxIter = 20]
- * @returns {MandeltestResult}
+ * @returns {number}
  */
 function testMandelbrot(c, maxIter = 200) {
     let z = { re: 0, im: 0 }

--- a/js/compy-stuff.js
+++ b/js/compy-stuff.js
@@ -11,13 +11,34 @@
  * @returns {number}
  */
 function testMandelbrot(c, maxIter = 200) {
-    let z = { re: 0, im: 0 }
-    for (let i = 0; i < maxIter; i++) {
-        complexSquare(z);
-        complexAdd(z, c);
-        if (squareComplexAbs(z) > 4) return i;
+    if (!testCardioid(c) && !testBulb(c)) {
+        let z = { re: 0, im: 0 }
+        for (let i = 0; i < maxIter; i++) {
+            complexSquare(z);
+            complexAdd(z, c);
+            if (squareComplexAbs(z) > 4) return i;
+        }
     }
     return maxIter;
+}
+
+/**
+ * @param {Complex} c
+ * @returns {boolean}
+ */
+function testCardioid(c) {
+    const a = (c.re - 1 / 4);
+    const q = a * a + c.im * c.im;
+    return q * (q + a) <= .25 * c.im * c.im;
+}
+
+/**
+ * @param {Complex} c
+ * @returns {boolean}
+ */
+function testBulb(c) {
+    const a = c.re + 1;
+    return a * a + c.im * c.im <= 1 / 16;
 }
 
 /**

--- a/js/compy-stuff.js
+++ b/js/compy-stuff.js
@@ -1,9 +1,24 @@
-/**
- * @typedef {Object} Complex
- *
- * @property {number} re
- * @property {number} im
- */
+class Complex {
+    constructor(re, im) {
+        this.re = re;
+        this.im = im;
+    }
+
+    add(other) {
+        this.re += other.re;
+        this.im += other.im;
+    }
+
+    square() {
+        const re = this.re * this.re - this.im * this.im;
+        this.im = this.re * this.im * 2;
+        this.re = re;
+    }
+
+    squareAbs() {
+        return this.re * this.re + this.im * this.im;
+    }
+}
 
 /**
  * @param {Complex} c
@@ -12,11 +27,11 @@
  */
 function testMandelbrot(c, maxIter = 200) {
     if (!testCardioid(c) && !testBulb(c)) {
-        let z = { re: 0, im: 0 }
+        let z = new Complex(0, 0);
         for (let i = 0; i < maxIter; i++) {
-            complexSquare(z);
-            complexAdd(z, c);
-            if (squareComplexAbs(z) > 4) return i;
+            z.square();
+            z.add(c);
+            if (z.squareAbs() > 4) return i;
         }
     }
     return maxIter;
@@ -39,47 +54,6 @@ function testCardioid(c) {
 function testBulb(c) {
     const a = c.re + 1;
     return a * a + c.im * c.im <= 1 / 16;
-}
-
-/**
- * @param {Complex} c
- * @param {{width: number, height: number}} dimensions
- * @param {{min: number, max: number}} xBounds
- * @param {{min: number, max: number}} yBounds
- * @param {number} maxIters
- */
-function determineHue(c, dimensions, xBounds, yBounds, maxIters = 200) {
-
-    const x = c.x
-    const y = c.y
-
-    let a = map(x, 0, dimensions.width, xBounds.min, xBounds.max)
-    let b = map(y, 0, dimensions.height, yBounds.min, yBounds.max)
-
-    const result = testMandelbrot({ re: a, im: b }, maxIters)
-
-    if (result.collapses) {
-        return [0]
-    } else {
-
-        const hue = 360 - map(result.iterBeforeCollapse, 0, maxIters, 0, 360)
-        return [hue, 255, 255]
-    }
-}
-
-function complexAdd(c, num2) {
-    c.re += num2.re;
-    c.im += num2.im;
-}
-
-function complexSquare(c) {
-    const re = (c.re * c.re) - (c.im * c.im);
-    c.im = (c.re * c.im) * 2;
-    c.re = re;
-}
-
-function squareComplexAbs(num) {
-    return num.re * num.re + num.im * num.im;
 }
 
 function map(n, start1, stop1, start2, stop2, withinBounds) {

--- a/js/compy-stuff.js
+++ b/js/compy-stuff.js
@@ -33,7 +33,8 @@ function testMandelbrot(c, maxIter = 200) {
 
         result.iterBeforeCollapse++
 
-        z = complexAdd(complexMult(z, z), c)
+        complexSquare(z);
+        complexAdd(z, c);
 
         if (squareComplexAbs(z) > 4) {
             result.collapses = false
@@ -71,18 +72,15 @@ function determineHue(c, dimensions, xBounds, yBounds, maxIters = 200) {
     }
 }
 
-function complexAdd(num1, num2) {
-    return {
-        re: num1.re + num2.re,
-        im: num1.im + num2.im
-    }
+function complexAdd(c, num2) {
+    c.re += num2.re;
+    c.im += num2.im;
 }
 
-function complexMult(num1, num2) {
-    return {
-        re: (num1.re * num2.re) - (num1.im * num2.im),
-        im: (num1.re * num2.im) + (num1.im * num2.re)
-    }
+function complexSquare(c) {
+    const re = (c.re * c.re) - (c.im * c.im);
+    c.im = (c.re * c.im) * 2;
+    c.re = re;
 }
 
 function squareComplexAbs(num) {

--- a/js/painter.js
+++ b/js/painter.js
@@ -101,7 +101,7 @@ function painter_center(x, y) {
 
 function painter_zoom_on(x, y, zoom) {
     const w = (bounds.x.max - bounds.x.min) * zoom;
-    const h = (bounds.y.max - bounds.y.min) * zoom;
+    const h = w * canvas.height / canvas.width;
 
     const shiftBoundsX = (x / canvas.width) * (bounds.x.max - bounds.x.min)
     const shiftBoundsY = (y / canvas.height) * (bounds.y.max - bounds.y.min)

--- a/js/painter.js
+++ b/js/painter.js
@@ -1,7 +1,7 @@
 let ctx
 let drawing = false
 
-const numOfAcolytes =  navigator.hardwareConcurrency || 4
+const numOfAcolytes = navigator.hardwareConcurrency || 4
 let acolytes
 let segmentLength
 
@@ -13,21 +13,21 @@ let maxIters = 256
 function painter_setup(data) {
     ctx = canvas.getContext('2d')
 
-    segmentLength = canvas.width / numOfAcolytes
+    segmentLength = canvas.height / numOfAcolytes | 0
 
     acolytes = _.times(numOfAcolytes, n => {
 
-        const xOffset = n * segmentLength
+        const yOffset = n * segmentLength
         const acolyte = new Worker('/js/acolyte.js')
 
         acolyte.onmessage = onAcolyteMessage
 
         acolyte.id = n
-        acolyte.xOffset = xOffset
+        acolyte.offset = { x: 0, y: yOffset }
         acolyte.segmentLength = segmentLength
         acolyte.dimensions = {
-            width: segmentLength,
-            height: canvas.height
+            width: canvas.width,
+            height: segmentLength
         };
 
         acolyte.postMessage({
@@ -37,7 +37,7 @@ function painter_setup(data) {
                 width: canvas.width,
                 height: canvas.height
             },
-            xOffset,
+            offset: acolyte.offset,
             xBounds,
             yBounds,
             maxIters
@@ -57,7 +57,7 @@ function onAcolyteMessage(event) {
             console.log(`Rendered tile in ${event.data.time}ms`)
             let data = new Uint8ClampedArray(event.data.buffer);
             let idata = new ImageData(data, acolyte.dimensions.width, acolyte.dimensions.height);
-            ctx.putImageData(idata, acolyte.xOffset, 0)
+            ctx.putImageData(idata, acolyte.offset.x, acolyte.offset.y)
             break
     }
 }

--- a/js/painter.js
+++ b/js/painter.js
@@ -1,7 +1,7 @@
 let ctx
 let drawing = false
 
-const numOfAcolytes =  navigator.hardwareConcurrency
+const numOfAcolytes =  navigator.hardwareConcurrency || 4
 let acolytes
 let segmentLength
 

--- a/js/painter.js
+++ b/js/painter.js
@@ -5,8 +5,6 @@ const numOfAcolytes = navigator.hardwareConcurrency || 4
 let acolytes
 let segmentLength
 
-const xBounds = { min: -3, max: 1 }
-const yBounds = { min: -1.5, max: 1.5 }
 
 let maxIters = 256
 
@@ -96,8 +94,6 @@ function painter_draw(data) {
 
         yBounds.min -= yZoom
         yBounds.max += yZoom
-
-        console.log(`New Bounds`, xBounds, yBounds)
     }
 
     for (const acolyte of acolytes) {

--- a/js/painter.js
+++ b/js/painter.js
@@ -66,7 +66,7 @@ class Acolyte {
     }
 }
 
-function painter_setup(data) {
+function painter_setup() {
     ctx = canvas.getContext('2d')
     acolytes = Array(numOfAcolytes).fill()
         .map((_, i) => new Acolyte(i));
@@ -86,18 +86,26 @@ function draw_tile(buffer, x, y, w, h) {
 }
 
 function painter_zoom(zoomBy) {
-    const xRange = bounds.x.max - bounds.x.min
-    const yRange = bounds.y.max - bounds.y.min
+    const dx = (bounds.x.max - bounds.x.min) / 2;
+    const dy = (bounds.y.max - bounds.y.min) / 2;
 
-    const xZoom = xRange * zoomBy
-    const yZoom = yRange * zoomBy
+    bounds.x.min += dx * zoomBy
+    bounds.x.max -= dx * zoomBy
+    bounds.y.min += dy * zoomBy
+    bounds.y.max -= dy * zoomBy
 
-    bounds.x.min -= xZoom
-    bounds.x.max += xZoom
+    update_bounds(bounds);
+}
 
-    bounds.y.min -= yZoom
-    bounds.y.max += yZoom
-
+function painter_move(x, y) {
+    const w = bounds.x.max - bounds.x.min
+    const h = bounds.y.max - bounds.y.min
+    const dx = -x * w / canvas.width
+    const dy = -y * h / canvas.width
+    bounds.x.min += dx
+    bounds.x.max += dx
+    bounds.y.min += dy
+    bounds.y.max += dy
     update_bounds(bounds);
 }
 

--- a/js/painter.js
+++ b/js/painter.js
@@ -1,12 +1,4 @@
-
-importScripts('https://cdnjs.cloudflare.com/ajax/libs/randomcolor/0.5.4/randomColor.js')
-importScripts('https://cdn.jsdelivr.net/npm/lodash@4.17.11/lodash.min.js')
-importScripts('/js/compy-stuff.js')
-importScripts('/js/util.js')
-
-let canvas
 let ctx
-
 let drawing = false
 
 const numOfAcolytes = 4
@@ -18,94 +10,46 @@ const yBounds = { min: -1.5, max: 1.5 }
 
 let maxIters = 256
 
-self.onmessage = function onmessage(event) {
+function painter_setup(data) {
+    ctx = canvas.getContext('2d')
 
-    switch (event.data.message) {
+    segmentLength = canvas.width / numOfAcolytes
 
-        case 'setup':
-            canvas = event.data.canvas
-            ctx = canvas.getContext('2d')
+    acolytes = _.times(numOfAcolytes, n => {
 
-            segmentLength = canvas.width / numOfAcolytes
+        const xOffset = n * segmentLength
+        const acolyte = new Worker('/js/acolyte.js')
 
-            acolytes = _.times(numOfAcolytes, n => {
+        acolyte.onmessage = onAcolyteMessage
 
-                const xOffset = n * segmentLength
-                const acolyte = new Worker('/js/acolyte.js')
+        acolyte.id = n
+        acolyte.xOffset = xOffset
+        acolyte.segmentLength = segmentLength
 
-                acolyte.onmessage = onAcolyteMessage
+        acolyte.canvas = new OffscreenCanvas(segmentLength, canvas.height)
+        acolyte.canvas.width = segmentLength
+        acolyte.canvas.height = canvas.height
 
-                acolyte.id = n
-                acolyte.xOffset = xOffset
-                acolyte.segmentLength = segmentLength
+        const offScreenSegment = acolyte.canvas
 
-                acolyte.canvas = new OffscreenCanvas(segmentLength, canvas.height)
-                acolyte.canvas.width = segmentLength
-                acolyte.canvas.height = canvas.height
+        acolyte.postMessage(
+            {
+                message: 'setup',
+                canvas: offScreenSegment,
+                maxDimensions: {
+                    width: canvas.width,
+                    height: canvas.height
+                },
+                xOffset,
+                xBounds,
+                yBounds,
+                maxIters
+            },
+            [offScreenSegment]
+        )
 
-                const offScreenSegment = acolyte.canvas
-
-                acolyte.postMessage(
-                    {
-                        message: 'setup',
-                        canvas: offScreenSegment,
-                        maxDimensions: {
-                            width: canvas.width,
-                            height: canvas.height
-                        },
-                        xOffset,
-                        xBounds,
-                        yBounds,
-                        maxIters
-                    },
-                    [offScreenSegment]
-                )
-
-                return acolyte
-            })
-            break
-
-        case 'draw':
-
-            const mousePos = {
-                x: _.get(event.data, 'mousePos.x'),
-                y: _.get(event.data, 'mousePos.y')
-            }
-
-            const zoomBy = _.get(event.data, 'zoom')
-
-            if (mousePos.x !== undefined) {
-
-                const shiftX = mousePos.x - (canvas.width / 2)
-                const shiftY = mousePos.y - (canvas.height / 2)
-
-                const shiftBoundsX = (shiftX / canvas.width) * (xBounds.max - xBounds.min)
-                const shiftBoundsY = (shiftY / canvas.height) * (yBounds.max - yBounds.min)
-
-                xBounds.min += shiftBoundsX
-                xBounds.max += shiftBoundsX
-
-                yBounds.min += shiftBoundsY
-                yBounds.max += shiftBoundsY
-            } else if (zoomBy) {
-
-                const xRange = xBounds.max - xBounds.min
-                const yRange = yBounds.max - yBounds.min
-
-                const xZoom = (xRange / 4) * zoomBy
-                const yZoom = (yRange / 4) * zoomBy
-
-                xBounds.min -= xZoom
-                xBounds.max += xZoom
-
-                yBounds.min -= yZoom
-                yBounds.max += yZoom
-
-                console.log(`New Bounds`, xBounds, yBounds)
-            }
-
-            draw()
-    }
+        return acolyte
+    })
 }
 
 function onAcolyteMessage(event) {
@@ -121,20 +65,50 @@ function onAcolyteMessage(event) {
     }
 }
 
-function draw() {
-
-    if (drawing) {
-        return
+function painter_draw(data) {
+    const mousePos = {
+        x: _.get(data, 'mousePos.x'),
+        y: _.get(data, 'mousePos.y')
     }
 
-    if (!ctx || !canvas) {
-        return
+    const zoomBy = _.get(data, 'zoom')
+
+    if (mousePos.x !== undefined) {
+
+        const shiftX = mousePos.x - (canvas.width / 2)
+        const shiftY = mousePos.y - (canvas.height / 2)
+
+        const shiftBoundsX = (shiftX / canvas.width) * (xBounds.max - xBounds.min)
+        const shiftBoundsY = (shiftY / canvas.height) * (yBounds.max - yBounds.min)
+
+        xBounds.min += shiftBoundsX
+        xBounds.max += shiftBoundsX
+
+        yBounds.min += shiftBoundsY
+        yBounds.max += shiftBoundsY
+    } else if (zoomBy) {
+
+        const xRange = xBounds.max - xBounds.min
+        const yRange = yBounds.max - yBounds.min
+
+        const xZoom = (xRange / 4) * zoomBy
+        const yZoom = (yRange / 4) * zoomBy
+
+        xBounds.min -= xZoom
+        xBounds.max += xZoom
+
+        yBounds.min -= yZoom
+        yBounds.max += yZoom
+
+        console.log(`New Bounds`, xBounds, yBounds)
     }
 
-    drawing = true
+    if (drawing || !ctx || !canvas) return;
+
+    drawing = true;
 
     for (const acolyte of acolytes) {
-        acolyte.postMessage({ message: 'draw',  xBounds, yBounds, maxIters })
+        acolyte.postMessage({ message: 'draw', xBounds, yBounds, maxIters })
     }
 
     drawing = false

--- a/js/painter.js
+++ b/js/painter.js
@@ -53,8 +53,8 @@ function onAcolyteMessage(event) {
     log(`Message from acolyte: ${acolyte.id}`)
 
     switch (event.data.message) {
-
         case 'draw':
+            console.log(`Rendered tile in ${event.data.time}ms`)
             let data = new Uint8ClampedArray(event.data.buffer);
             let idata = new ImageData(data, acolyte.dimensions.width, acolyte.dimensions.height);
             ctx.putImageData(idata, acolyte.xOffset, 0)

--- a/js/painter.js
+++ b/js/painter.js
@@ -25,28 +25,23 @@ function painter_setup(data) {
         acolyte.id = n
         acolyte.xOffset = xOffset
         acolyte.segmentLength = segmentLength
+        acolyte.dimensions = {
+            width: segmentLength,
+            height: canvas.height
+        };
 
-        acolyte.canvas = new OffscreenCanvas(segmentLength, canvas.height)
-        acolyte.canvas.width = segmentLength
-        acolyte.canvas.height = canvas.height
-
-        const offScreenSegment = acolyte.canvas
-
-        acolyte.postMessage(
-            {
-                message: 'setup',
-                canvas: offScreenSegment,
-                maxDimensions: {
-                    width: canvas.width,
-                    height: canvas.height
-                },
-                xOffset,
-                xBounds,
-                yBounds,
-                maxIters
+        acolyte.postMessage({
+            message: 'setup',
+            dimensions: acolyte.dimensions,
+            maxDimensions: {
+                width: canvas.width,
+                height: canvas.height
             },
-            [offScreenSegment]
-        )
+            xOffset,
+            xBounds,
+            yBounds,
+            maxIters
+        })
 
         return acolyte
     })
@@ -60,7 +55,9 @@ function onAcolyteMessage(event) {
     switch (event.data.message) {
 
         case 'draw':
-            ctx.putImageData(event.data.img, acolyte.xOffset, 0)
+            let data = new Uint8ClampedArray(event.data.buffer);
+            let idata = new ImageData(data, acolyte.dimensions.width, acolyte.dimensions.height);
+            ctx.putImageData(idata, acolyte.xOffset, 0)
             break
     }
 }
@@ -103,13 +100,7 @@ function painter_draw(data) {
         console.log(`New Bounds`, xBounds, yBounds)
     }
 
-    if (drawing || !ctx || !canvas) return;
-
-    drawing = true;
-
     for (const acolyte of acolytes) {
         acolyte.postMessage({ message: 'draw', xBounds, yBounds, maxIters })
     }
-
-    drawing = false
 }

--- a/js/painter.js
+++ b/js/painter.js
@@ -60,32 +60,32 @@ class Acolyte {
                     offset: { x, y }
                 } = this;
                 const { buffer } = event.data;
-                draw_tile(buffer, x, y, width, height);
+                drawTile(buffer, x, y, width, height);
                 break
         }
     }
 }
 
-function painter_setup() {
+function painterSetup() {
     ctx = canvas.getContext('2d')
     acolytes = Array(numOfAcolytes).fill()
         .map((_, i) => new Acolyte(i));
 }
 
 
-const update_bounds = function update_bounds(bounds) {
+const updateBounds = function updateBounds(bounds) {
     for (const acolyte of acolytes) {
         acolyte.draw(bounds)
     }
 };
 
-function draw_tile(buffer, x, y, w, h) {
+function drawTile(buffer, x, y, w, h) {
     let data = new Uint8ClampedArray(buffer);
     let idata = new ImageData(data, w, h);
     ctx.putImageData(idata, x, y);
 }
 
-function painter_zoom(zoomBy) {
+function painterZoom(zoomBy) {
     const dx = (bounds.x.max - bounds.x.min) / 2;
     const dy = (bounds.y.max - bounds.y.min) / 2;
 
@@ -94,10 +94,10 @@ function painter_zoom(zoomBy) {
     bounds.y.min += dy * zoomBy
     bounds.y.max -= dy * zoomBy
 
-    update_bounds(bounds);
+    updateBounds(bounds);
 }
 
-function painter_move(x, y) {
+function painterMove(x, y) {
     const w = bounds.x.max - bounds.x.min
     const h = bounds.y.max - bounds.y.min
     const dx = -x * w / canvas.width
@@ -106,11 +106,11 @@ function painter_move(x, y) {
     bounds.x.max += dx
     bounds.y.min += dy
     bounds.y.max += dy
-    update_bounds(bounds);
+    updateBounds(bounds);
 }
 
 
-function painter_center(x, y) {
+function painterCenter(x, y) {
     const shiftX = x - (canvas.width / 2)
     const shiftY = y - (canvas.height / 2)
 
@@ -123,10 +123,10 @@ function painter_center(x, y) {
     bounds.y.min += shiftBoundsY
     bounds.y.max += shiftBoundsY
 
-    update_bounds(bounds);
+    updateBounds(bounds);
 }
 
-function painter_zoom_on(x, y, zoom) {
+function painterZoomOn(x, y, zoom) {
     const w = (bounds.x.max - bounds.x.min) * zoom;
     const h = w * canvas.height / canvas.width;
 
@@ -138,5 +138,5 @@ function painter_zoom_on(x, y, zoom) {
     bounds.y.min += shiftBoundsY - h * (y / canvas.height);
     bounds.y.max = bounds.y.min + h;
 
-    update_bounds(bounds);
+    updateBounds(bounds);
 }

--- a/js/painter.js
+++ b/js/painter.js
@@ -1,7 +1,7 @@
 let ctx
 let drawing = false
 
-const numOfAcolytes = 4
+const numOfAcolytes =  navigator.hardwareConcurrency
 let acolytes
 let segmentLength
 

--- a/js/sketch.js
+++ b/js/sketch.js
@@ -1,13 +1,13 @@
 let canvas = document.getElementById('fractal')
 const { width, height } = canvas.getBoundingClientRect();
-const xBounds = { min: -3, max: 1 }
-const yBounds = { min: -1.5, max: 1.5 }
-yBounds.max = yBounds.min + (xBounds.max - xBounds.min) * height / width;
+const bounds = { x: { min: -3, max: 1 }, y: { min: -1.5, max: 1.5 } }
+bounds.y.max = bounds.y.min + (bounds.x.max - bounds.x.min) * height / width;
 
 function setup() {
     canvas.width = width
     canvas.height = height
-    document.addEventListener('keydown', zoomListener, false)
+    document.addEventListener('keydown', zoomListener, false);
+    document.addEventListener('wheel', onWheel, { passive: false });
     $(canvas).click(clickListener)
 
     const message = { message: 'setup', canvas };
@@ -23,7 +23,7 @@ function clickListener(e) {
     const mouseX = e.pageX - parentOffset.left;
     const mouseY = e.pageY - parentOffset.top;
 
-    painter_draw({ mousePos: { x: mouseX, y: mouseY } })
+    painter_zoom_on(mouseX, mouseY, .7);
 }
 
 function zoomListener(event) {
@@ -32,13 +32,19 @@ function zoomListener(event) {
 
         event.preventDefault()
 
-        let zoom = 1
+        let zoom = 0.25
+        if (event.keyCode === 38) zoom = -zoom;
 
-        if (event.keyCode === 38) {
-            zoom = -zoom
-        }
-        painter_draw({ zoom })
+        painter_zoom(zoom)
     }
+}
+
+function onWheel(e) {
+    e.preventDefault();
+    const parentOffset = $(canvas).offset()
+    const mouseX = e.pageX - parentOffset.left;
+    const mouseY = e.pageY - parentOffset.top;
+    painter_zoom_on(mouseX, mouseY, 1 + e.deltaY / 100)
 }
 
 setup()

--- a/js/sketch.js
+++ b/js/sketch.js
@@ -10,7 +10,7 @@ function setup() {
 
     document.addEventListener('keydown', zoomListener, false);
     document.addEventListener('wheel', onWheel, { passive: false });
-    $(canvas).click(clickListener)
+    document.addEventListener('click', clickListener, { passive: true });
 
     const message = { message: 'setup', canvas };
     painter_setup(message)
@@ -19,13 +19,7 @@ function setup() {
 }
 
 function clickListener(e) {
-
-    const parentOffset = $(this).offset()
-
-    const mouseX = e.pageX - parentOffset.left;
-    const mouseY = e.pageY - parentOffset.top;
-
-    painter_zoom_on(mouseX, mouseY, .7);
+    painter_zoom_on(e.offsetX, e.offsetY, .75);
 }
 
 function zoomListener(event) {
@@ -43,10 +37,7 @@ function zoomListener(event) {
 
 function onWheel(e) {
     e.preventDefault();
-    const parentOffset = $(canvas).offset()
-    const mouseX = e.pageX - parentOffset.left;
-    const mouseY = e.pageY - parentOffset.top;
-    painter_zoom_on(mouseX, mouseY, 1 + e.deltaY / 100)
+    painter_zoom_on(e.offsetX, e.offsetY, 1 + e.deltaY / 100)
 }
 
 setup()

--- a/js/sketch.js
+++ b/js/sketch.js
@@ -2,8 +2,6 @@ let canvas
 const width = 600
 const height = 450
 
-const painter = new Worker('/js/painter.js')
-
 function setup() {
 
     canvas = document.createElement('canvas')
@@ -13,15 +11,8 @@ function setup() {
     document.addEventListener('keydown', zoomListener, false)
     $(canvas).click(clickListener)
 
-    const offScreen = canvas.transferControlToOffscreen()
-
-    const message = {
-        message: 'setup',
-        canvas: offScreen
-    }
-    const transfers = [offScreen]
-
-    painter.postMessage(message, transfers)
+    const message = { message: 'setup', canvas };
+    painter_setup(message)
 
     document.querySelector('body').appendChild(canvas)
     log('setup done')
@@ -34,7 +25,7 @@ function clickListener(e) {
     const mouseX = e.pageX - parentOffset.left;
     const mouseY = e.pageY - parentOffset.top;
 
-    painter.postMessage({message: 'draw', mousePos: {x: mouseX, y: mouseY}})
+    painter_draw({ mousePos: { x: mouseX, y: mouseY } })
 }
 
 function zoomListener(event) {
@@ -48,7 +39,7 @@ function zoomListener(event) {
         if (event.keyCode === 38) {
             zoom = -zoom
         }
-        painter.postMessage({message: 'draw', zoom})
+        painter_draw({ zoom })
     }
 }
 

--- a/js/sketch.js
+++ b/js/sketch.js
@@ -1,11 +1,10 @@
-let canvas
-const width = 600
-const height = 450
+let canvas = document.getElementById('fractal')
+const { width, height } = canvas.getBoundingClientRect();
+const xBounds = { min: -3, max: 1 }
+const yBounds = { min: -1.5, max: 1.5 }
+yBounds.max = yBounds.min + (xBounds.max - xBounds.min) * height / width;
 
 function setup() {
-
-    canvas = document.createElement('canvas')
-
     canvas.width = width
     canvas.height = height
     document.addEventListener('keydown', zoomListener, false)
@@ -14,7 +13,6 @@ function setup() {
     const message = { message: 'setup', canvas };
     painter_setup(message)
 
-    document.querySelector('body').appendChild(canvas)
     log('setup done')
 }
 

--- a/js/sketch.js
+++ b/js/sketch.js
@@ -1,11 +1,13 @@
 let canvas = document.getElementById('fractal')
 const { width, height } = canvas.getBoundingClientRect();
-const bounds = { x: { min: -3, max: 1 }, y: { min: -1.5, max: 1.5 } }
-bounds.y.max = bounds.y.min + (bounds.x.max - bounds.x.min) * height / width;
+const bounds = { x: { min: -3, max: 2 }, y: { min: -1.3, max: 1.3 } }
 
 function setup() {
     canvas.width = width
     canvas.height = height
+    bounds.y.max = .5 * (bounds.x.max - bounds.x.min) * height / width;
+    bounds.y.min = -.5 * (bounds.x.max - bounds.x.min) * height / width;
+
     document.addEventListener('keydown', zoomListener, false);
     document.addEventListener('wheel', onWheel, { passive: false });
     $(canvas).click(clickListener)

--- a/js/sketch.js
+++ b/js/sketch.js
@@ -10,16 +10,21 @@ function setup() {
 
     document.addEventListener('keydown', zoomListener, false);
     document.addEventListener('wheel', onWheel, { passive: false });
-    document.addEventListener('click', clickListener, { passive: true });
+    document.addEventListener('dblclick', clickListener, { passive: false });
+    document.addEventListener('mousemove', mouseListener, { passive: true });
 
-    const message = { message: 'setup', canvas };
-    painter_setup(message)
-
-    log('setup done')
+    painter_setup()
 }
 
 function clickListener(e) {
-    painter_zoom_on(e.offsetX, e.offsetY, .75);
+    e.preventDefault();
+    painter_zoom_on(e.offsetX, e.offsetY, 0.5);
+}
+
+function mouseListener(e) {
+    if (e.buttons & 1) {
+        painter_move(e.movementX, e.movementY);
+    }
 }
 
 function zoomListener(event) {
@@ -27,9 +32,8 @@ function zoomListener(event) {
     if (event.altKey && event.keyCode === 38 || event.keyCode === 40) {
 
         event.preventDefault()
-
-        let zoom = 0.25
-        if (event.keyCode === 38) zoom = -zoom;
+        const z = 0.25
+        let zoom = (event.keyCode === 38) ? z : -z;
 
         painter_zoom(zoom)
     }

--- a/js/sketch.js
+++ b/js/sketch.js
@@ -13,17 +13,17 @@ function setup() {
     document.addEventListener('dblclick', clickListener, { passive: false });
     document.addEventListener('mousemove', mouseListener, { passive: true });
 
-    painter_setup()
+    painterSetup()
 }
 
 function clickListener(e) {
     e.preventDefault();
-    painter_zoom_on(e.offsetX, e.offsetY, 0.5);
+    painterZoomOn(e.offsetX, e.offsetY, 0.5);
 }
 
 function mouseListener(e) {
     if (e.buttons & 1) {
-        painter_move(e.movementX, e.movementY);
+        painterMove(e.movementX, e.movementY);
     }
 }
 
@@ -35,13 +35,13 @@ function zoomListener(event) {
         const z = 0.25
         let zoom = (event.keyCode === 38) ? z : -z;
 
-        painter_zoom(zoom)
+        painterZoom(zoom)
     }
 }
 
 function onWheel(e) {
     e.preventDefault();
-    painter_zoom_on(e.offsetX, e.offsetY, 1 + e.deltaY / 100)
+    painterZoomOn(e.offsetX, e.offsetY, 1 + e.deltaY / 100)
 }
 
 setup()

--- a/style.css
+++ b/style.css
@@ -14,4 +14,6 @@ body {
 canvas {
     display: block;
     border: #3c3c3c 1px solid;
+    width: 100%;
+    height: 100%;
 }


### PR DESCRIPTION
Switch from using 1 pixel `fillRect` on an offscreen canvas to using a typed array on the workers. This improves rendering performance, and makes this work on non-chrome browsers.
Tested on chrome, firefox and safari. 